### PR TITLE
Added ICspAsymmetricAlgorithm implementation

### DIFF
--- a/src/Pkcs11Interop.X509Store/Pkcs11RsaProvider.cs
+++ b/src/Pkcs11Interop.X509Store/Pkcs11RsaProvider.cs
@@ -26,18 +26,22 @@ using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
 
+
 namespace Net.Pkcs11Interop.X509Store
 {
     /// <summary>
     /// PKCS#11 based implementation of the RSA algorithm
     /// </summary>
-    public class Pkcs11RsaProvider : RSA
+    public class Pkcs11RsaProvider : RSA, ICspAsymmetricAlgorithm
     {
+        /// <summary>
+        /// Internal csp blob data 
+        /// </summary>
+        private byte[] _cspBlob;
         /// <summary>
         /// Internal context for Pkcs11X509Certificate2 class
         /// </summary>
         private Pkcs11X509CertificateContext _certContext = null;
-
         /// <summary>
         /// Creates new instance of Pkcs11RsaProvider class
         /// </summary>
@@ -47,6 +51,11 @@ namespace Net.Pkcs11Interop.X509Store
             _certContext = certContext ?? throw new ArgumentNullException(nameof(certContext));
             base.KeySizeValue = _certContext.CertificateInfo.ParsedCertificate.GetRSAPublicKey().KeySize;
             base.LegalKeySizesValue = new KeySizes[] { new KeySizes(base.KeySizeValue, base.KeySizeValue, 0) };
+
+            // Load csp blob from public key RSACryptoServiceProvider
+            X509Certificate2 cert = new X509Certificate2(certContext.CertificateInfo.RawData);
+            RSACryptoServiceProvider RSApubkey = (RSACryptoServiceProvider)cert.PublicKey.Key;
+            this._cspBlob = RSApubkey.ExportCspBlob(false);
         }
 
         /// <summary>
@@ -319,5 +328,49 @@ namespace Net.Pkcs11Interop.X509Store
 
             return pssParams;
         }
+
+        /// <summary>
+        /// Returns information for the CSP container
+        /// </summary>
+        public CspKeyContainerInfo CspKeyContainerInfo
+        {
+            get
+            {
+                CspParameters cspParameters = new CspParameters();
+
+                // This could be updated/changed
+                cspParameters.ProviderName = "PKCS11Interop";
+                cspParameters.KeyContainerName = "unknown";
+                cspParameters.KeyNumber = 1; // privateKey.CspKeyContainerInfo.KeyNumber;
+                cspParameters.ProviderType = 1;
+                cspParameters.Flags = CspProviderFlags.UseNonExportableKey;
+
+                CspKeyContainerInfo cspKeyContainerInfo = new CspKeyContainerInfo(cspParameters);
+
+                return cspKeyContainerInfo;
+            }
+        }
+
+        /// <summary>
+        /// Exports csp blob data 
+        /// </summary>
+        /// <param name="includePrivateParameters">false not to include parameters </param>
+        /// <returns></returns>
+        public byte[] ExportCspBlob(bool includePrivateParameters)
+        {
+            if (includePrivateParameters)
+                throw new NotSupportedException("Private key export is not supported");
+            return this._cspBlob;
+        }
+
+        /// <summary>
+        /// Import csp blob data
+        /// </summary>
+        /// <param name="_cspBlob">csp blob data to import</param>
+        public void ImportCspBlob(byte[] _cspBlob)
+        {
+            this._cspBlob = _cspBlob;
+        }
     }
 }
+


### PR DESCRIPTION
Updated `Pkcs11RsaProvider` to support `ICspAsymmetricAlgorithm` in order to be possible the Private key to be imported into `X509Certificate2` object. Useful when `X509Certificate2` is passed into a code and somewhere later the signing is done.

Added properties:
```csharp
private byte[] _cspBlob;
```

Updated methods:
```csharp
// added _cspBlob data generation from RSACryptoServiceProvider using the PublicKey
internal Pkcs11RsaProvider(Pkcs11X509CertificateContext certContext);
```

Added methods:
```csharp
public CspKeyContainerInfo CspKeyContainerInfo; //NOTE not precise and could be improved
public byte[] ExportCspBlob(bool includePrivateParameters);
public void ImportCspBlob(byte[] _cspBlob);
```

Possible usage:
```csharp
// Load the Pkcs11X509Store 
Pkcs11X509Store store = new Pkcs11X509Store(@"C:\Windows\SysWow64\cmP11.dll", new ConstPinProvider("1234"));

Pkcs11X509Certificate pkcs11cert = store.Slots[0].Token.Certificates[0];

// Crate X509Certificate2 object with just a certificate
X509Certificate2 x509Certificate2 = new X509Certificate2(pkcs11cert.Info.RawData);

// Get PKCS#11 based private key
RSA rsaPrivateKey = (RSA)pkcs11cert.GetRSAPrivateKey();

//Set the private key to be used by Pkcs11RsaProvider
Pkcs11RsaProvider pkcs11RsaPrivateKey = (Pkcs11RsaProvider)rsaPrivateKey;

// Extend X509Certificate2 with the private key
x509Certificate2.PrivateKey = pkcs11RsaPrivateKey;

// Do the signature          
byte[] sig = x509Certificate2.GetRSAPrivateKey().SignData(input, hashAlgorithmName, rSASignaturePadding);
```