### PR TITLE
FindKeyNoCkaLabel

### DIFF
--- a/src/Pkcs11Interop.X509Store/Pkcs11X509Certificate.cs
+++ b/src/Pkcs11Interop.X509Store/Pkcs11X509Certificate.cs
@@ -150,7 +150,6 @@ namespace Net.Pkcs11Interop.X509Store
                 session.Factories.ObjectAttributeFactory.Create(CKA.CKA_CLASS, keyClass),
                 session.Factories.ObjectAttributeFactory.Create(CKA.CKA_TOKEN, true),
                 session.Factories.ObjectAttributeFactory.Create(CKA.CKA_ID, ckaId),
-                session.Factories.ObjectAttributeFactory.Create(CKA.CKA_LABEL, ckaLabel)
             };
 
             foreach (IObjectHandle foundObjectHandle in session.FindAllObjects(searchTemplate))


### PR DESCRIPTION
FindKey not to use CKA.CKA_LABEL in case label is set on certificate, but not in the public/private keys.